### PR TITLE
Fix encoding bug

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,1 +1,2 @@
 Edwin Lunando / @edwinlunando
+Flávio Juvenal / @fjsj

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ First, install django-naomi by using pip. You can add `django-naomi` to your req
 
 Then, add `naomi` to your `INSTALLED_APPS` on your django settings file. ::
 
-    INSTALLED_APPS += 'naomi'
+    INSTALLED_APPS += ['naomi']
 
 
 Lastly, change the Django email backend and set the temporary directory. ::

--- a/naomi/mail/backends/naomi.py
+++ b/naomi/mail/backends/naomi.py
@@ -23,7 +23,7 @@ class NaomiBackend(EmailBackend):
         if six.PY3:
             self.stream.write(bytes(template_content, 'UTF-8'))
         else:
-            self.stream.write(template_content)
+            self.stream.write(template_content.encode('UTF-8'))
 
     def _get_filename(self):
         """Return a unique file name."""

--- a/naomi/templates/naomi/message.html
+++ b/naomi/templates/naomi/message.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <meta http-equiv="Content-Type" content="text/html">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     {% if message.subject %}
         <title>{{ message.subject }}</title>
     {% endif %}


### PR DESCRIPTION
[Django generally returns unicode strings](https://docs.djangoproject.com/en/1.7/ref/unicode/#general-string-handling). I was getting encoding errors, so I think the correct is to encode the `template_content`.

Also I fixed the `INSTALLED_APPS` in the README.
