### PR TITLE
Moving webbrowser.open to close method and adding file://

### DIFF
--- a/naomi/mail/backends/naomi.py
+++ b/naomi/mail/backends/naomi.py
@@ -31,8 +31,12 @@ class NaomiBackend(EmailBackend):
             timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
             fname = "%s-%s.html" % (timestamp, abs(id(self)))
             self._fname = os.path.join(self.file_path, fname)
-            webbrowser.open(self._fname)
         return self._fname
+
+    def close(self):
+        result = super(NaomiBackend, self).close()
+        webbrowser.open('file://' + self._fname)
+        return result
 
     def send_messages(self, email_messages):
         """Write all messages to the stream in a thread-safe way."""


### PR DESCRIPTION
Moved `webbrowser.open` to `close` method, because there it is guaranteed that the file will be already created.

Also, on my platform (Chrome and OSX Yosemite), the plain `webbrowser.open(file_path)` does not work. But when I try `webbrowser.open('file://' + file_path)`, it works. So I added the `file://` protocol. Also, [letter_opener does the same](https://github.com/ryanb/letter_opener/blob/master/lib/letter_opener/delivery_method.rb), but could you please test it on Windows?
