### PR TITLE
Allows attachments as tuples

### DIFF
--- a/naomi/mail/backends/naomi.py
+++ b/naomi/mail/backends/naomi.py
@@ -20,10 +20,16 @@ class NaomiBackend(EmailBackend):
         if hasattr(message, 'attachments') and message.attachments:
             temporary_path = settings.EMAIL_FILE_PATH
             for attachment in message.attachments:
-                new_file = open(os.path.join(temporary_path, attachment.name), 'wb+')
-                new_file.write(attachment.read())
-                attachments.append([attachment.name, new_file.name])
-                new_file.close()
+                if isinstance(attachment, tuple):
+                    new_file = open(os.path.join(temporary_path, attachment[0]), 'wb+')
+                    new_file.write(attachment[1])
+                    attachments.append([attachment[0], new_file.name])
+                    new_file.close()
+                else:
+                    new_file = open(os.path.join(temporary_path, attachment.name), 'wb+')
+                    new_file.write(attachment.read())
+                    attachments.append([attachment.name, new_file.name])
+                    new_file.close()
         if hasattr(message, 'alternatives') and message.alternatives:
             body = message.alternatives[0][0]
         else:


### PR DESCRIPTION
In trying to use `django-mail-templated` along with some file attachments. Unfortunately the attachment type that is produced using [`EmailMessage#attach_file`](http://django-mail-templated.readthedocs.org/en/master/_modules/django/core/mail/message.html#EmailMessage.attach_file) is a tuple, not an attachment instance.

I'm not sure if we can get `django-mail-templated` to conform to the attachment type that `django-naomi` is anticipating.
